### PR TITLE
Use `yaml.stringify`, which has better block formatt output controls.

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -27,13 +27,12 @@
     "@dqbd/tiktoken": "^1.0.7",
     "gitignore-parser": "^0.0.2",
     "gray-matter": "^4.0.3",
-    "js-yaml": "^4.1.0",
     "mustache": "^4.2.0",
     "openai": "^4.11.1",
-    "vectra": "^0.6.0"
+    "vectra": "^0.6.0",
+    "yaml": "^2.4.1"
   },
   "devDependencies": {
-    "@types/js-yaml": "^4.0.8",
     "@types/mustache": "^4.2.5",
     "vitest": "^0.34.6"
   }

--- a/core/src/content/content.ts
+++ b/core/src/content/content.ts
@@ -8,7 +8,8 @@ import {
   isAbsolute,
 } from "@davidsouther/jiffies/lib/esm/fs.js";
 import matter from "gray-matter";
-import * as yaml from "js-yaml";
+// import * as yaml from "js-yaml";
+import { stringify } from "yaml";
 import { join, dirname } from "path";
 import type { Message } from "../engine/index.js";
 import { isDefined } from "../util.js";
@@ -307,7 +308,7 @@ async function writeSingleContent(fs: FileSystem, content: Content) {
     meta.prompt = content.meta?.prompt ?? content.prompt;
   }
 
-  const head = yaml.dump(meta, { sortKeys: true });
+  const head = stringify(meta, { blockQuote: "literal", lineWidth: 0 });
   const file = `---\n${head}---\n${content.response}`;
   await fs.writeFile(path, file);
 }


### PR DESCRIPTION
Closes #25 
