### PR TITLE
Allow specifying template-view as a file in aillyrc

### DIFF
--- a/core/src/content/content.test.ts
+++ b/core/src/content/content.test.ts
@@ -801,3 +801,20 @@ test("it loads template views from system files", async () => {
     whiz: 12,
   });
 });
+
+test("it loads template-view in .aillyrc", async () => {
+  const fs = new FileSystem(
+    new ObjectFileSystemAdapter({
+      root: {
+        ".aillyrc": "---\ntemplate-view: ../view.yaml\n---",
+        "content.md": "{{view}}",
+      },
+      "view.yaml": "view: foo",
+    })
+  );
+  const content = await loadContent(fs);
+
+  expect(content["/root/content.md"].context.system?.[0].view).toEqual({
+    view: "foo",
+  });
+});


### PR DESCRIPTION
.aillyrc can specify `template-view`, which will attempt to load a path as yaml, and then merge it with the (optional) `view`.