### PR TITLE
Add copy buttons to prompt and response outputs

### DIFF
--- a/web/src/app/response.tsx
+++ b/web/src/app/response.tsx
@@ -4,6 +4,7 @@ import M from "@/components/M";
 import { useAillyPageStore } from "./store";
 import styles from "./response.module.css";
 import { Tab, TabList } from "@/components/Tabs";
+import { Copy } from "@/components/Copy";
 
 export const Response = (store: ReturnType<typeof useAillyPageStore>) => {
   const { state } = store;
@@ -17,9 +18,22 @@ export const Response = (store: ReturnType<typeof useAillyPageStore>) => {
       ) : (
         <TabList>
           <Tab title="Response">
+            {state.response.content && (
+              <Copy contents={state.response.content}></Copy>
+            )}
             <M>{state.response.content}</M>
           </Tab>
           <Tab title="Prompt">
+            <Copy
+              contents={JSON.stringify(
+                {
+                  system: state.content?.context.system?.map((s) => s.content),
+                  user: state.content?.prompt,
+                },
+                undefined,
+                "\t"
+              )}
+            ></Copy>
             <h2>System</h2>
             {state.content?.context.system?.map((s, i) => (
               <p key={i}>{s.content}</p>

--- a/web/src/components/Copy.module.css
+++ b/web/src/components/Copy.module.css
@@ -1,0 +1,4 @@
+.button {
+  float: right;
+  margin: 0 0 var(--size-base) var(--size-base);
+}

--- a/web/src/components/Copy.tsx
+++ b/web/src/components/Copy.tsx
@@ -1,0 +1,14 @@
+import { useCallback } from "react";
+import styles from "./Copy.module.css";
+
+export const Copy = (props: { contents: string }) => {
+  const copy = useCallback(() => {
+    window.navigator.clipboard.writeText(props.contents);
+  }, [props.contents]);
+
+  return (
+    <button className={styles.button} onClick={copy}>
+      <span className="material-symbols-outlined">content_copy</span>
+    </button>
+  );
+};


### PR DESCRIPTION
![image](https://github.com/DavidSouther/ailly/assets/498712/fa498f1f-f0f6-4cb2-aefb-f61700dba99f)

> Here's an example of how changing the prompt can affect the output from a language model when asking it to "make a sandwich": ...

![image](https://github.com/DavidSouther/ailly/assets/498712/39006ac2-4f41-4338-93ef-80df01b7540c)

```
{
	"system": [
		"<role>You are a software engineer developing a tool to teach non-technical people how prompt engineering affects LLM outputs.</role>"
	],
	"user": "Make a sandwich"
}
```