### PR TITLE
Refactor: consolidate edit messages.

### DIFF
--- a/cli/args.js
+++ b/cli/args.js
@@ -16,7 +16,7 @@ export function makeArgs(argv = process.argv) {
       engine: { type: "string", default: process.env["AILLY_ENGINE"] },
       model: { type: "string", default: process.env["AILLY_MODEL"] },
       plugin: { type: "string", default: process.env["AILLY_PLUGIN"] ?? "noop", },
-      context: { type: "string", default: process.env["AILLY_CONTEXT"] ?? "content", short: "c" },
+      context: { type: "string", default: process.env["AILLY_CONTEXT"], short: "c" },
       "template-view": { type: "string", default: process.env["AILLY_TEMPLATE_VIEW"] ? [process.env["AILLY_TEMPLATE_VIEW"]] : [], multiple: true },
       prompt: { type: "string", default: process.env["AILLY_PROMPT"], short: "p" },
       system: { type: "string", default: process.env["AILLY_SYSTEM"], short: "s" },
@@ -58,8 +58,8 @@ export function help() {
     --combined will force files to output as combined.
     -o, --out specify an output folder to work with responses. Defaults to --root. Will load responses from and write outputs to here, using .ailly file extensions.
     -c, --context conversation | folder | none
-      'conversation' (default) loads files from the root folder and includes them alphabetically, chatbot history style, before the current file when generating.
-      'folder' includes all files in the folder at the same level as the current file when generating.
+      'conversation' (default, unless --edit) loads files from the root folder and includes them alphabetically, chatbot history style, before the current file when generating.
+      'folder' includes all files in the folder at the same level as the current file when generating. Default with --edit.
       'none' includes no additional content (including no system context) when generating.
       (note: context is separate from isolated. isolated: true with either 'content' or 'folder' will result in the same behavior with either. With 'none', Ailly will send _only_ the prompt when generating.)
 

--- a/cli/fs.test.ts
+++ b/cli/fs.test.ts
@@ -73,7 +73,8 @@ describe("makeCLIContent", () => {
       state.context,
       state.root,
       edit,
-      view
+      view,
+      false
     );
 
     expect(cliContent).toEqual({
@@ -105,7 +106,8 @@ describe("makeCLIContent", () => {
       state.context,
       state.root,
       edit,
-      view
+      view,
+      false
     );
 
     expect(cliContent).toEqual({
@@ -137,7 +139,8 @@ describe("makeCLIContent", () => {
       state.context,
       state.root,
       edit,
-      view
+      view,
+      false
     );
 
     expect(cliContent).toEqual({
@@ -169,7 +172,8 @@ describe("makeCLIContent", () => {
       state.context,
       state.root,
       edit,
-      view
+      view,
+      false
     );
 
     expect(cliContent).toEqual({

--- a/core/src/actions/prompt_thread.ts
+++ b/core/src/actions/prompt_thread.ts
@@ -192,13 +192,11 @@ async function generateOne(
     messages: meta?.messages
       ?.map((m) => ({
         role: m.role,
-        content: m.content.replace(/\n/g, " ").substring(0, 150) + "...",
+        content: m.content,
         // tokens: m.tokens,
       }))
       // Skip the last `assistant` message
-      .filter((m, i, a) => !(m.role == "assistant" && i === a.length - 1))
-      .map(({ role, content }) => `${role}: ${content.replace(/\n/g, "\\n")}`)
-      .join("\n\t"),
+      .filter((m, i, a) => !(m.role == "assistant" && i === a.length - 1)),
   });
   const generated = await engine.generate(c, settings);
   c.response = generated.message;

--- a/core/src/content/content.ts
+++ b/core/src/content/content.ts
@@ -294,9 +294,15 @@ export async function loadContent(
       }
       break;
     case "folder":
-      const folder = files.map((f) => f.path);
-      for (const file of files) {
-        file.context.folder = folder;
+      if (isIsolated) {
+        for (const file of files) {
+          file.context.folder = [file.path];
+        }
+      } else {
+        const folder = files.map((f) => f.path);
+        for (const file of files) {
+          file.context.folder = folder;
+        }
       }
       break;
   }

--- a/core/src/engine/messages.ts
+++ b/core/src/engine/messages.ts
@@ -1,0 +1,119 @@
+import { dirname } from "node:path";
+import { Content } from "../content/content.js";
+import { isDefined } from "../util.js";
+import { Message } from "./index.js";
+
+export async function addContentMessages(
+  content: Content,
+  context: Record<string, Content>
+) {
+  content.meta ??= {};
+  if (content.context.folder)
+    content.meta.messages = getMessagesFolder(content, context);
+  else content.meta.messages = getMessagesPredecessor(content, context);
+  let messages = content.meta.messages;
+  if (messages.at(-1)?.role == "assistant") {
+    messages = messages.slice(0, -1);
+  }
+  let fence: undefined | string = undefined;
+  if (content.context.edit) {
+    const lang = content.context.edit.file.split(".").at(-1) ?? "";
+    fence = "```" + lang;
+    const { start, end } = content.context.edit as {
+      start?: number;
+      end?: number;
+    };
+    if (start != undefined) {
+      if (messages.at(-1)?.role === "user") {
+        messages.at(-1)!.content = [
+          "You are replacing this section:",
+          "```",
+          ...(content.meta?.text?.split("\n").slice(start, end) ?? []),
+          "```",
+          "",
+          messages.at(-1)!.content,
+        ].join("\n");
+      }
+    }
+    messages.push({ role: "assistant", content: fence });
+  }
+}
+
+export function getMessagesPredecessor(
+  content: Content,
+  context: Record<string, Content>
+): Message[] {
+  const system = (content.context.system ?? [])
+    .map((s) => s.content)
+    .join("\n");
+  const history: Content[] = [];
+  while (content) {
+    history.push(content);
+    content = context[content.context.predecessor!];
+  }
+  history.reverse();
+  const augment = history
+    .map<Array<Message | undefined>>(
+      (c) =>
+        (c.context.augment ?? []).map<Message>(({ content }) => ({
+          role: "user",
+          content:
+            "Use this code block as background information for format and style, but not for functionality:\n```\n" +
+            content +
+            "\n```\n",
+        })) ?? []
+    )
+    .flat()
+    .filter(isDefined);
+  const parts = history
+    .map<Array<Message | undefined>>((content) => [
+      {
+        role: "user",
+        content: content.prompt,
+      },
+      content.response
+        ? { role: "assistant", content: content.response }
+        : undefined,
+    ])
+    .flat()
+    .filter(isDefined);
+  return [{ role: "system", content: system }, ...augment, ...parts];
+}
+
+export function getMessagesFolder(
+  content: Content,
+  context: Record<string, Content>
+): Message[] {
+  const system =
+    (content.context.system ?? []).map((s) => s.content).join("\n") +
+    "\n" +
+    "Instructions are happening in the context of this folder:\n" +
+    `<folder name="${content.meta?.root ?? dirname(content.path)}">\n` +
+    (content.context.folder ?? [])
+      .map((c) => context[c])
+      .map<string>(
+        (c) =>
+          `<file name="${c.name}>\n${
+            c.meta?.text ?? c.prompt + "\n" + c.response
+          }</file>`
+      )
+      .join("\n") +
+    "\n</folder>";
+
+  const history: Content[] = [content];
+  const augment: Message[] = [];
+
+  const parts = history
+    .map<Array<Message | undefined>>((content) => [
+      {
+        role: "user",
+        content: content.prompt,
+      },
+      content.response
+        ? { role: "assistant", content: content.response }
+        : undefined,
+    ])
+    .flat()
+    .filter(isDefined);
+  return [{ role: "system", content: system }, ...augment, ...parts];
+}

--- a/core/src/engine/noop.ts
+++ b/core/src/engine/noop.ts
@@ -3,6 +3,7 @@ import { Content } from "../content/content.js";
 import { LOGGER as ROOT_LOGGER } from "../util.js";
 import type { PipelineSettings } from "../ailly.js";
 import type { Message } from "./index.js";
+import { addContentMessages } from "./messages.js";
 
 const LOGGER = getLogger("@ailly/core:noop");
 
@@ -21,18 +22,7 @@ export async function format(
   context: Record<string, Content>
 ): Promise<void> {
   for (const content of contents) {
-    let messages: Message[] = [];
-    if (content.context.folder) {
-      messages = Object.values(context).map<Message[]>(asMessages).flat();
-    } else if (content.context.predecessor) {
-      let history = [context[content.context.predecessor]];
-      while (history.at(-1)?.context.predecessor) {
-        history.push(context[history.at(-1)?.context?.predecessor!]);
-      }
-      messages = history.reverse().map(asMessages).flat();
-    }
-    content.meta ??= {};
-    content.meta.messages = messages;
+    addContentMessages(content, context);
   }
 }
 export async function generate<D extends {} = {}>(

--- a/integ/integ.sh
+++ b/integ/integ.sh
@@ -22,10 +22,14 @@ npx ailly --root 02_combined --combined
 git restore 02_combined/combined.txt
 
 echo "edit"
-AILLY_NOOP_RESPONSE="Edited" npx ailly --root 04_edit --edit file --lines 2:4 --prompt "Respond with the word Edited" --yes
+AILLY_NOOP_RESPONSE="Edited" \
+  npx ailly --root 04_edit --edit file.txt --lines 2:4 --prompt "Respond with the word Edited" --yes \
+  --verbose > >(tee ./04_edit/out) 2> >(tee ./04_edit/err >&2)
 grep -q 'Edited' 04_edit/file.txt
+grep -q 'Instructions are happening in the context of this folder' 04_edit/out
+grep -q 'You are replacing this section:\\n```\\nLine 2\\nLine 3\\n```' 04_edit/out
 git restore 04_edit/file.txt
-unset AILLY_NOOP_RESPONSE
+rm 04_edit/{err,out}
 
 echo "conversations"
 ./05_conversation/conversation.sh


### PR DESCRIPTION
* Extract edit prompting from Bedrock
* Improve FS reporting and defaults for single-file edits
* `--context folder --isolated`  only reports the one file in the folder (still uses system) (equivalent to a `--context file` approach)
* Better fills in CLI Content meta.