### PR TITLE
Feat: --prompt --stream for Bedrock and noop engines.

### DIFF
--- a/cli/args.js
+++ b/cli/args.js
@@ -20,6 +20,7 @@ export function makeArgs(argv = process.argv) {
       "template-view": { type: "string", default: process.env["AILLY_TEMPLATE_VIEW"] ? [process.env["AILLY_TEMPLATE_VIEW"]] : [], multiple: true },
       prompt: { type: "string", default: process.env["AILLY_PROMPT"], short: "p" },
       system: { type: "string", default: process.env["AILLY_SYSTEM"], short: "s" },
+      stream: { type: 'boolean', default: false },
       "request-limit": { type: "string", default: process.env["AILLY_REQUEST_LIMIT"] },
       "max-depth": { type: "string", default: "1" },
       temperature: { type: "string", default: "" },
@@ -63,6 +64,7 @@ export function help() {
       'none' includes no additional content (including no system context) when generating.
       (note: context is separate from isolated. isolated: true with either 'content' or 'folder' will result in the same behavior with either. With 'none', Ailly will send _only_ the prompt when generating.)
 
+    --stream (--prompt only) print responses as they return.
     -e, --edit use Ailly in edit mode. Provide a single file in paths, an edit marker, and a prompt. The path will be updated with the edit marker at the prompt.
     -l, --lines the lines to edit as '[start]:[end]' with start inclusive, and end exclusive. With only '[start]', will insert after. With only ':[end]', will insert before.
 

--- a/core/src/actions/prompt_thread.test.ts
+++ b/core/src/actions/prompt_thread.test.ts
@@ -9,21 +9,9 @@ import {
   ObjectFileSystemAdapter,
 } from "@davidsouther/jiffies/lib/esm/fs";
 import { getPlugin, makePipelineSettings } from "../ailly";
-import { ENGINES, getEngine } from "../engine";
+import { getEngine } from "../engine";
 import { LEVEL } from "@davidsouther/jiffies/lib/esm/log";
 import { TIMEOUT } from "../engine/noop";
-
-Promise.withResolvers =
-  Promise.withResolvers ??
-  function makePromise<T = void>(): PromiseWithResolvers<T> {
-    let resolve: (t: T | PromiseLike<T>) => void = () => {};
-    let reject: (reason?: any) => void = () => {};
-    const promise = new Promise<T>((r, j) => {
-      resolve = r;
-      reject = j;
-    });
-    return { promise, resolve, reject };
-  };
 
 describe("scheduler", () => {
   it("limits outstanding tasks", async () => {

--- a/core/src/actions/prompt_thread.test.ts
+++ b/core/src/actions/prompt_thread.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { range } from "@davidsouther/jiffies/lib/esm/range.js";
+import { PromptThread, generateOne, scheduler } from "./prompt_thread";
+import { LOGGER } from "../util";
+import { cleanState } from "@davidsouther/jiffies/lib/esm/scope/state";
+import { loadContent } from "../content/content";
+import {
+  FileSystem,
+  ObjectFileSystemAdapter,
+} from "@davidsouther/jiffies/lib/esm/fs";
+import { getPlugin, makePipelineSettings } from "../ailly";
+import { ENGINES, getEngine } from "../engine";
+import { LEVEL } from "@davidsouther/jiffies/lib/esm/log";
+import { TIMEOUT } from "../engine/noop";
+
+Promise.withResolvers =
+  Promise.withResolvers ??
+  function makePromise<T = void>(): PromiseWithResolvers<T> {
+    let resolve: (t: T | PromiseLike<T>) => void = () => {};
+    let reject: (reason?: any) => void = () => {};
+    const promise = new Promise<T>((r, j) => {
+      resolve = r;
+      reject = j;
+    });
+    return { promise, resolve, reject };
+  };
+
+describe("scheduler", () => {
+  it("limits outstanding tasks", async () => {
+    const tasks = range(0, 5).map((i) => ({
+      i,
+      started: false,
+      finished: false,
+      ...Promise.withResolvers<void>(),
+    }));
+    const runners = tasks.map((task) => async () => {
+      console.log(`starting ${task.i}`);
+      task.started = true;
+      await task.promise;
+      console.log(`finishing ${task.i}`);
+      task.finished = true;
+    });
+
+    scheduler(runners, 2);
+
+    expect(tasks[0].started).toBe(true);
+    expect(tasks[1].started).toBe(true);
+    expect(tasks[2].started).toBe(false);
+    expect(tasks[3].started).toBe(false);
+    expect(tasks[4].started).toBe(false);
+
+    await Promise.resolve().then(() => tasks[0].resolve());
+    expect(tasks[0].finished).toBe(true);
+    await Promise.resolve(); // Allow outstanding to clear
+    await Promise.resolve(); // Allow loop to continue
+
+    expect(tasks[1].started).toBe(true);
+    expect(tasks[2].started).toBe(true);
+    expect(tasks[3].started).toBe(false);
+    expect(tasks[4].started).toBe(false);
+  });
+});
+
+describe("generateOne", () => {
+  let level = LOGGER.level;
+  const state = cleanState(async () => {
+    const logger = {
+      info: vi.spyOn(LOGGER, "info"),
+      debug: vi.spyOn(LOGGER, "debug"),
+    };
+    LOGGER.level = LEVEL.SILENT;
+    const context = await loadContent(
+      new FileSystem(
+        new ObjectFileSystemAdapter({
+          "a.txt": `prompt a`,
+          "a.txt.ailly.md": `response a`,
+          "b.txt": `---\nprompt: prompt b\nskip: true\n---\nresponse b`,
+          "c.txt": "tell me a joke\n",
+        })
+      )
+    );
+    const engine = await getEngine("noop");
+    TIMEOUT.setTimeout(0);
+    expect(logger.debug).toHaveBeenCalledWith("Loading content from /");
+    expect(logger.debug).toHaveBeenCalledWith("Found 3 at or below /");
+    expect(logger.info).toHaveBeenCalledTimes(0);
+    logger.debug.mockClear();
+    logger.info.mockClear();
+    return { logger, context, engine };
+  }, beforeEach);
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    LOGGER.level = level;
+    TIMEOUT.resetTimeout();
+  });
+
+  it("skips some", async () => {
+    generateOne(
+      state.context["/a.txt"],
+      state.context,
+      await makePipelineSettings({ root: "/", overwrite: false }),
+      state.engine
+    );
+    expect(state.logger.info).toHaveBeenCalledWith("Skipping /a.txt");
+    state.logger.info.mockClear();
+
+    generateOne(
+      state.context["/b.txt"],
+      state.context,
+      await makePipelineSettings({ root: "/" }),
+      state.engine
+    );
+    expect(state.logger.info).toHaveBeenCalledWith("Skipping /b.txt");
+    state.logger.info.mockClear();
+  });
+
+  it("generates others", async () => {
+    const content = state.context["/c.txt"];
+    expect(content.response).toBeUndefined();
+    await generateOne(
+      content,
+      state.context,
+      await makePipelineSettings({ root: "/" }),
+      state.engine
+    );
+    expect(state.logger.info).toHaveBeenCalledWith("Preparing /c.txt");
+    expect(state.logger.info).toHaveBeenCalledWith("Calling noop");
+    expect(content.response).toMatch(/^noop response for c.txt:/);
+  });
+});
+
+describe("PromptThread", () => {
+  let level = LOGGER.level;
+  const state = cleanState(async () => {
+    const logger = {
+      info: vi.spyOn(LOGGER, "info"),
+      debug: vi.spyOn(LOGGER, "debug"),
+    };
+    LOGGER.level = LEVEL.SILENT;
+    const fs = new FileSystem(
+      new ObjectFileSystemAdapter({
+        "a.txt": `prompt a`,
+        "a.txt.ailly.md": `response a`,
+        "b.txt": `---\nprompt: prompt b\nskip: true\n---\nresponse b`,
+        "c.txt": "tell me a joke\n",
+      })
+    );
+    const engine = await getEngine("noop");
+    TIMEOUT.setTimeout(0);
+    return { logger, fs, engine };
+  }, beforeEach);
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    LOGGER.level = level;
+    TIMEOUT.resetTimeout();
+  });
+
+  it("runs isolated", async () => {
+    const settings = await makePipelineSettings({ root: "/", isolated: true });
+    const context = await loadContent(state.fs, [], { isolated: true });
+    state.logger.debug.mockClear();
+    state.logger.info.mockClear();
+    const content = [...Object.values(context)];
+    const plugin = await (
+      await getPlugin("none")
+    ).default(state.engine, settings);
+    const thread = PromptThread.run(
+      content,
+      context,
+      settings,
+      state.engine,
+      plugin
+    );
+    expect(thread.isDone).toBe(false);
+    expect(thread.finished).toBe(0);
+    expect(thread.errors.length).toBe(0);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    // Enough to get one resolved
+
+    expect(thread.isDone).toBe(false);
+    expect(thread.finished).toBe(1);
+    expect(thread.errors.length).toBe(0);
+
+    await thread.allSettled();
+
+    expect(thread.isDone).toBe(true);
+    expect(thread.finished).toBe(3);
+    expect(thread.errors.length).toBe(0);
+
+    expect(content[0].response).toEqual(
+      `noop response for a.txt:\n\nsystem: \nuser: prompt a\nassistant: response a\nprompt a`
+    );
+    expect(content[1].response).toBeUndefined();
+    expect(content[2].response).toEqual(
+      `noop response for c.txt:\n\nsystem: \nuser: tell me a joke\n\ntell me a joke\n`
+    );
+  });
+
+  it("runs sequence", async () => {
+    const settings = await makePipelineSettings({ root: "/" });
+    const context = await loadContent(state.fs);
+    state.logger.debug.mockClear();
+    state.logger.info.mockClear();
+    const content = [...Object.values(context)];
+    const plugin = await (
+      await getPlugin("none")
+    ).default(state.engine, settings);
+    const thread = PromptThread.run(
+      content,
+      context,
+      settings,
+      state.engine,
+      plugin
+    );
+    expect(thread.isDone).toBe(false);
+    expect(thread.finished).toBe(0);
+    expect(thread.errors.length).toBe(0);
+
+    await thread.allSettled();
+
+    expect(thread.isDone).toBe(true);
+    expect(thread.finished).toBe(3);
+    expect(thread.errors.length).toBe(0);
+
+    expect(content[0].response).toEqual(
+      `noop response for a.txt:\n\nsystem: \nuser: prompt a\nassistant: response a\nprompt a`
+    );
+    expect(content[1].response).toBeUndefined();
+    expect(content[2].response).toEqual(
+      `noop response for c.txt:\n\nsystem: \nuser: prompt a\nassistant: noop response for a.txt:\n\nsystem: \nuser: prompt a\nassistant: response a\nprompt a\nuser: response b\nuser: tell me a joke\n\ntell me a joke\n`
+    );
+  });
+});

--- a/core/src/actions/prompt_thread.ts
+++ b/core/src/actions/prompt_thread.ts
@@ -206,7 +206,7 @@ export async function generateOne(
     },
   };
   const generated = await engine.generate(c, settings);
-  c.response = generated.message;
+  c.response = generated.message();
   c.meta.debug = { ...c.meta.debug, ...generated.debug };
   return c;
 }

--- a/core/src/actions/prompt_thread.ts
+++ b/core/src/actions/prompt_thread.ts
@@ -28,7 +28,7 @@ export async function scheduler<T>(
   let finished: Array<Promise<T>> = [];
   let outstanding = new Set<Promise<T>>();
   while (taskQueue.length > 0) {
-    if (outstanding.size > limit) {
+    if (outstanding.size >= limit) {
       // Wait for something in outstanding to finish
       await Promise.race([...outstanding]);
     } else {
@@ -47,7 +47,7 @@ export async function scheduler<T>(
 export class PromptThread {
   finished: number = 0;
   isolated: boolean = false;
-  done: boolean = false;
+  private done: boolean = false;
   runner?: Promise<PromiseSettledResult<Content>[]>;
   // Results holds a list of errors that occurred and the index the occurred at.
   // If the thread is isolated, this can have many entries. If the thread is not
@@ -87,7 +87,7 @@ export class PromptThread {
     private plugin: Plugin
   ) {
     this.content = content;
-    this.isolated = Boolean(content[0]?.meta?.isolated ?? false);
+    this.isolated = Boolean(settings.isolated ?? false);
   }
 
   start() {
@@ -168,7 +168,7 @@ export class PromptThread {
   }
 }
 
-async function generateOne(
+export async function generateOne(
   c: Content,
   context: Record<string, Content>,
   settings: PipelineSettings,

--- a/core/src/actions/prompt_thread.ts
+++ b/core/src/actions/prompt_thread.ts
@@ -198,15 +198,15 @@ export async function generateOne(
       // Skip the last `assistant` message
       .filter((m, i, a) => !(m.role == "assistant" && i === a.length - 1)),
   });
-  const generated = await engine.generate(c, settings);
-  c.response = generated.message;
   c.meta = {
     ...c.meta,
     debug: {
-      ...generated.debug,
       engine: settings.engine,
       model: settings.model,
     },
   };
+  const generated = await engine.generate(c, settings);
+  c.response = generated.message;
+  c.meta.debug = { ...c.meta.debug, ...generated.debug };
   return c;
 }

--- a/core/src/content/content.test.ts
+++ b/core/src/content/content.test.ts
@@ -39,7 +39,7 @@ test("it loads content", async () => {
       path: "/01_start.md",
       outPath: "/01_start.md.ailly.md",
       prompt: "The quick brown",
-      response: "",
+      response: undefined,
       context: {
         system: [],
         view: {},
@@ -56,7 +56,7 @@ test("it loads content", async () => {
       path: "/20b/40_part.md",
       outPath: "/20b/40_part.md.ailly.md",
       prompt: "fox jumped",
-      response: "",
+      response: undefined,
       context: {
         system: [],
         view: {},
@@ -73,7 +73,7 @@ test("it loads content", async () => {
       path: "/20b/56_part.md",
       outPath: "/20b/56_part.md.ailly.md",
       prompt: "over the lazy",
-      response: "",
+      response: undefined,
       context: {
         system: [],
         view: {},
@@ -91,7 +91,7 @@ test("it loads content", async () => {
       path: "/54_a/12_section.md",
       outPath: "/54_a/12_section.md.ailly.md",
       prompt: "dog.",
-      response: "",
+      response: undefined,
       context: {
         system: [],
         view: {},
@@ -156,7 +156,7 @@ test("it loads combined prompt and responses", async () => {
       path: "/prompt.md",
       outPath: "/prompt.md",
       prompt: "prompt",
-      response: "",
+      response: undefined,
       context: {
         system: [],
         view: {},
@@ -233,7 +233,7 @@ test("it loads separate prompt and responses", async () => {
       path: "/prompt.md",
       outPath: "/prompt.md.ailly.md",
       prompt: "prompt",
-      response: "",
+      response: undefined,
       context: {
         system: [],
         view: {},
@@ -292,7 +292,7 @@ test("it loads separate prompt and responses in different out directors", async 
       path: "/root/prompt.md",
       outPath: "/out/prompt.md.ailly.md",
       prompt: "prompt",
-      response: "",
+      response: undefined,
       context: {
         system: [],
         view: {},
@@ -407,7 +407,7 @@ test("it writes deep java prompts and responses", async () => {
       path: "/root/src/com/example/Main.java",
       outPath: "/out/src/com/example/Main.java.ailly.md",
       prompt: "class Main {}\n",
-      response: "",
+      response: undefined,
       context: {
         system: [],
         view: {},
@@ -668,7 +668,7 @@ describe("Load aillyrc", () => {
         path: "/root/b",
         outPath: "/root/b.ailly.md",
         prompt: "b",
-        response: "",
+        response: undefined,
         context: {
           view: {},
         },

--- a/core/src/content/content.ts
+++ b/core/src/content/content.ts
@@ -30,6 +30,7 @@ export interface Content {
   // The prompt itself
   prompt: string;
   response?: string;
+  responseStream?: ReadableStream;
   context: Context;
   meta?: ContentMeta;
 }

--- a/core/src/content/content.ts
+++ b/core/src/content/content.ts
@@ -93,7 +93,6 @@ function partitionDirectory(stats: Stats[]): PartitionedDirectory {
 async function loadDir(fs: FileSystem): Promise<PartitionedDirectory> {
   const dir = await fs.readdir(".");
   const entries = await Promise.all(dir.map((s) => fs.stat(s)));
-  // const entries = await fs.scandir("");
   return partitionDirectory(entries);
 }
 
@@ -143,7 +142,7 @@ async function loadFile(
       );
     }
 
-    let response = "";
+    let response: string | undefined;
     let outPath: string;
     if (data.prompt) {
       outPath = promptPath;
@@ -171,6 +170,7 @@ async function loadFile(
         }
       }
     }
+    if (response?.trim() == "") response = undefined;
 
     const view = data.view === false ? false : data.view ?? {};
     delete data.view;

--- a/core/src/content/content.ts
+++ b/core/src/content/content.ts
@@ -57,7 +57,7 @@ export interface ContentMeta {
   skip?: boolean;
   isolated?: boolean;
   combined?: boolean;
-  debug?: unknown;
+  debug?: {};
   view?: false | View;
   prompt?: string;
   temperature?: number;

--- a/core/src/engine/index.ts
+++ b/core/src/engine/index.ts
@@ -5,10 +5,16 @@ import * as mistral from "./mistral/mistral.js";
 import * as noop from "./noop.js";
 import { PipelineSettings } from "../ailly.js";
 
-export type EngineGenerate<D extends {} = {}> = (
-  c: Content,
-  parameters: PipelineSettings
-) => Promise<{ stream: ReadableStream; message(): string; debug(): D }>;
+export type EngineGenerate<D extends { finish?: string; error?: Error } = {}> =
+  (
+    c: Content,
+    parameters: PipelineSettings
+  ) => {
+    stream: ReadableStream;
+    message(): string;
+    debug(): D;
+    done: Promise<void>;
+  };
 
 export interface Engine {
   DEFAULT_MODEL: string;

--- a/core/src/engine/index.ts
+++ b/core/src/engine/index.ts
@@ -5,14 +5,16 @@ import * as mistral from "./mistral/mistral.js";
 import * as noop from "./noop.js";
 import { PipelineSettings } from "../ailly.js";
 
+export type EngineGenerate<D extends {} = {}> = (
+  c: Content,
+  parameters: PipelineSettings
+) => Promise<{ stream: ReadableStream; message(): string; debug(): D }>;
+
 export interface Engine {
   DEFAULT_MODEL: string;
   name: string;
   format(c: Content[], context: Record<string, Content>): Promise<void>;
-  generate<D extends {} = {}>(
-    c: Content,
-    parameters: PipelineSettings
-  ): Promise<{ debug: D; message: string }>;
+  generate: EngineGenerate;
   vector(s: string, parameters: ContentMeta): Promise<number[]>;
   view?(): Promise<View>;
   models?(): string[];

--- a/core/src/engine/mistral/mistral.ts
+++ b/core/src/engine/mistral/mistral.ts
@@ -1,45 +1,62 @@
+import { EngineGenerate } from "..";
 import type { Content } from "../../content/content.js";
 import * as openai from "../openai.js";
 import { spawn } from "node:child_process";
 import { normalize, join, dirname } from "node:path";
 
-const MODEL = "mistralai/Mistral-7B-v0.1";
+const DEFAULT_MODEL = "mistralai/Mistral-7B-v0.1";
+interface MistralDebug {}
 
-export async function generate(
+export const generate: EngineGenerate<MistralDebug> = async (
   c: Content,
-  {}: {}
-): Promise<{ message: string; debug: unknown }> {
-  return new Promise<{ message: string; debug: unknown }>((resolve, reject) => {
-    const prompt = c.meta?.messages?.map(({ content }) => content).join("\n");
-    if (!prompt) {
-      return reject("No messages in Content");
-    }
+  { model = DEFAULT_MODEL }: { model?: string }
+) => {
+  const prompt = c.meta?.messages?.map(({ content }) => content).join("\n");
+  if (!prompt) {
+    throw new Error("No messages in Content");
+  }
 
-    let cwd = dirname(
-      (import.meta?.url.replace(/^file:/, "") ?? __filename).replace(
-        "ailly/core/dist",
-        "ailly/core/src"
-      )
-    );
-    let command = join(cwd, normalize(".venv/bin/python3"));
-    let args = [join(cwd, "mistral.py"), prompt];
-    let child = spawn(command, args, { cwd });
+  let cwd = dirname(
+    (import.meta?.url.replace(/^file:/, "") ?? __filename).replace(
+      "ailly/core/dist",
+      "ailly/core/src"
+    )
+  );
+  let command = join(cwd, normalize(".venv/bin/python3"));
+  let args = [join(cwd, "mistral.py"), prompt];
+  let child = spawn(command, args, { cwd });
 
-    let response = "";
-    child.on("message", (m) => (response += `${m}`));
+  const stream = new TransformStream();
 
-    const done = () => {
-      resolve({ message: response, debug: {} });
-    };
-    child.on("exit", done);
-    child.on("close", done);
-    child.on("disconnect", done);
-
-    const error = (cause: unknown) =>
-      reject(new Error("child_process had a problem" /*, { cause }*/));
-    child.on("error", error);
+  let message = "";
+  child.on("message", async (m) => {
+    const writer = await stream.writable.getWriter();
+    await writer.ready;
+    await writer.write(m);
+    writer.releaseLock();
+    message += `${m}`;
   });
-}
+
+  const done = () => {
+    stream.writable.close();
+  };
+  child.on("exit", done);
+  child.on("close", done);
+  child.on("disconnect", done);
+
+  const error = (cause: unknown) => {
+    stream.writable.abort(
+      `child_process had a problem ${JSON.stringify(cause)}`
+    );
+  };
+  child.on("error", error);
+
+  return {
+    stream: stream.readable,
+    message: () => message,
+    debug: () => ({}),
+  };
+};
 
 export const format = openai.format;
 export const getMessages = openai.getMessages;
@@ -48,7 +65,7 @@ export async function tune(
   content: Content[],
   context: Record<string, Content>,
   {
-    model = MODEL,
+    model = DEFAULT_MODEL,
     apiKey = process.env["OPENAI_API_KEY"] ?? "",
     baseURL = "http://localhost:8000/v1",
   }: { model: string; apiKey: string; baseURL: string }

--- a/core/src/engine/noop.ts
+++ b/core/src/engine/noop.ts
@@ -2,20 +2,21 @@ import { getLogger } from "@davidsouther/jiffies/lib/esm/log.js";
 import { Content } from "../content/content.js";
 import { LOGGER as ROOT_LOGGER } from "../util.js";
 import type { PipelineSettings } from "../ailly.js";
-import type { Message } from "./index.js";
 import { addContentMessages } from "./messages.js";
 
 const LOGGER = getLogger("@ailly/core:noop");
 
-const asMessages = (content: Content) => [
-  { role: "user", content: content.prompt } satisfies Message,
-  ...(content.response
-    ? [{ role: "assistant", content: content.response } satisfies Message]
-    : []),
-];
-
 export const DEFAULT_MODEL = "NOOP";
-const NOOP_TIMEOUT = Number(process.env["AILLY_NOOP_TIMEOUT"] ?? 750);
+export const TIMEOUT = {
+  timeout: 0,
+  setTimeout(timeout: number) {
+    TIMEOUT.timeout = timeout;
+  },
+  resetTimeout() {
+    TIMEOUT.setTimeout(Number(process.env["AILLY_NOOP_TIMEOUT"] ?? 750));
+  },
+};
+TIMEOUT.resetTimeout();
 export const name = "noop";
 export async function format(
   contents: Content[],
@@ -32,7 +33,7 @@ export async function generate<D extends {} = {}>(
   LOGGER.level = ROOT_LOGGER.level;
   LOGGER.format = ROOT_LOGGER.format;
   await new Promise<void>((resolve) => {
-    setTimeout(() => resolve(), NOOP_TIMEOUT);
+    setTimeout(() => resolve(), TIMEOUT.timeout);
   });
   const system = content.context.system?.map((s) => s.content).join("\n");
   const messages = content.meta?.messages

--- a/core/src/engine/noop.ts
+++ b/core/src/engine/noop.ts
@@ -3,6 +3,7 @@ import { Content } from "../content/content.js";
 import { LOGGER as ROOT_LOGGER } from "../util.js";
 import type { PipelineSettings } from "../ailly.js";
 import { addContentMessages } from "./messages.js";
+import { EngineGenerate } from ".";
 
 const LOGGER = getLogger("@ailly/core:noop");
 
@@ -18,6 +19,7 @@ export const TIMEOUT = {
 };
 TIMEOUT.resetTimeout();
 export const name = "noop";
+
 export async function format(
   contents: Content[],
   context: Record<string, Content>
@@ -26,31 +28,45 @@ export async function format(
     addContentMessages(content, context);
   }
 }
-export async function generate<D extends {} = {}>(
+
+export interface MistralDebug {}
+
+export const generate: EngineGenerate<MistralDebug> = async (
   content: Content,
   _: PipelineSettings
-): Promise<{ debug: D; message: string }> {
+) => {
   LOGGER.level = ROOT_LOGGER.level;
   LOGGER.format = ROOT_LOGGER.format;
   await new Promise<void>((resolve) => {
     setTimeout(() => resolve(), TIMEOUT.timeout);
   });
+
   const system = content.context.system?.map((s) => s.content).join("\n");
   const messages = content.meta?.messages
     ?.map((m) => `${m.role}: ${m.content}`)
     .join("\n");
+  const message =
+    process.env["AILLY_NOOP_RESPONSE"] ??
+    [
+      `noop response for ${content.name}:`,
+      system,
+      messages,
+      content.prompt,
+    ].join("\n");
+
+  const stream = new TextEncoderStream();
+  Promise.resolve().then(async () => {
+    const writer = await stream.writable.getWriter();
+    await writer.ready;
+    await writer.write(message);
+    writer.close();
+  });
   return {
-    message:
-      process.env["AILLY_NOOP_RESPONSE"] ??
-      [
-        `noop response for ${content.name}:`,
-        system,
-        messages,
-        content.prompt,
-      ].join("\n"),
-    debug: { system: content.context.system } as unknown as D,
+    stream: stream.readable,
+    message: () => message,
+    debug: () => ({}),
   };
-}
+};
 export async function vector(s: string, _: unknown): Promise<number[]> {
   return [0.0, 1.0];
 }

--- a/core/src/plugin/index.ts
+++ b/core/src/plugin/index.ts
@@ -20,7 +20,7 @@ export const PLUGINS: Record<string, { default: PluginBuilder }> = {
 };
 
 export async function getPlugin(
-  name: string
+  name: keyof typeof PLUGINS | string
 ): Promise<{ default: PluginBuilder }> {
   if (name.startsWith("file://")) {
     return import(name);

--- a/core/src/util.ts
+++ b/core/src/util.ts
@@ -4,3 +4,15 @@ export const LOGGER = getLogger("@ailly/core");
 LOGGER.level = getLogLevel(process.env["AILLY_LOG_LEVEL"]);
 
 export const isDefined = <T>(t: T | undefined): t is T => t !== undefined;
+
+Promise.withResolvers =
+  Promise.withResolvers ??
+  function makePromise<T = void>(): PromiseWithResolvers<T> {
+    let resolve: (t: T | PromiseLike<T>) => void = () => {};
+    let reject: (reason?: any) => void = () => {};
+    const promise = new Promise<T>((r, j) => {
+      resolve = r;
+      reject = j;
+    });
+    return { promise, resolve, reject };
+  };

--- a/integ/06_stream/stream.sh
+++ b/integ/06_stream/stream.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+cd $(dirname $0)
+set -x
+set -e
+
+AILLY_NOOP_STREAM=y ailly --prompt "Tell me a joke" --stream | tee out
+[ -s out ]
+rm out

--- a/integ/integ.sh
+++ b/integ/integ.sh
@@ -34,6 +34,9 @@ rm 04_edit/{err,out}
 echo "conversations"
 ./05_conversation/conversation.sh
 
+echo "Stream"
+./06_stream/stream.sh
+
 echo "Pipes"
 ./10_std_pipes/pipes.sh
 


### PR DESCRIPTION
Streaming responses in the CLI, now the "long" part is waiting for first response which can take a bit for larger contexts.

Demo:

https://github.com/DavidSouther/ailly/assets/498712/5e7db272-6563-41d0-9ee5-8f16a4de2ab2

Closes #71
Groundwork for #65 
