### PR TITLE
Cleanup/getting started/cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@ Write your outline.
 Prompt Ailly to continue to keep writing.
 Edit its output, and get even more text like that.
 
-Rhymes with *daily*.
+Rhymes with _daily_.
 
 Ailly's best feature is rapid prompt engineering iteration. By keeping your prompts in snippets on the file system, you can make very fine-grained changes to your prompt and immediately see the difference in the output. You can also use all of your normal source control tooling to track changes over time: both your changes, and those from the LLM.
 
-## Quickstart
+## CLI Quickstart
 
-To get started, follow these steps:
+To get started on the command line, follow these steps:
 
-1. Create a folder named `jokes` and `cd` into it.
-2. Create a file named `10_chickens.md` with "Tell me a joke about chickens" as the content.
-3. Run Ailly using NodeJS: `npx @ailly/cli`
+1. Ask for a joke - `npx @ailly/cli --prompt 'Tell me a joke'`
+1. Create a folder named `jokes` and change directory into it.
+1. Create a file named `10_chickens.md` with "Tell me a joke about chickens" as the content.
+1. Run Ailly using NodeJS: `npx @ailly/cli`
    - See the joke in `10_chickens.md.ailly.md`
-2. Create a file named `jokes/.aillyrc` with "You are a farmer writing jokes for your other barnyard animals."
+1. Create a file named `.aillyrc` with "You are a farmer writing jokes for your other barnyard animals."
    - Include other system prompts, level setting expectations. etc.
    - Run Ailly with the same command, and see how the joke changes.
-3. Create more numbered files, such as `jokes/20_knock_knock.md` with "Turn the chicken joke into a knock knock joke."
-4. Run Ailly using NodeJS: `npx @ailly/cli 20_knock_knock.md`
-  - Ailly will send each file to the configured LLM engine and write its result.
-  - `20_knock_knock.md.ailly.md` will have the new knock knock joke based on the chicken joke it first wrote!
+1. Create more numbered files, such as `20_knock_knock.md` with "Turn the chicken joke into a knock knock joke."
+1. Run Ailly using NodeJS: `npx @ailly/cli 20_knock_knock.md`
+   - `20_knock_knock.md.ailly.md` will have the new knock knock joke based on the chicken joke it first wrote!
 
 ### System Context
 

--- a/cli/src/args.ts
+++ b/cli/src/args.ts
@@ -57,7 +57,7 @@ export function makeArgs(argv = process.argv) {
       help: { type: "boolean", short: "h", default: false },
       version: { type: "boolean", default: false },
       "log-level": { type: "string", default: undefined },
-      "log-format": { type: "string", default: undefined },
+      "log-format": { type: "string", default: "pretty" },
       verbose: { type: "boolean", default: false, short: "v" },
     },
   });
@@ -106,7 +106,7 @@ export function help() {
     --summary will show a pricing expectation before running and prompt for OK.
     -y, —-yes will skip any prompts.
     -v, --verbose, --log-level v and verbose will set log level to info; --log-level can be a string or number and use jefri/jiffies logging levels. Ailly uses warn for reporting details on errors, info for general runtime progress, and debug for details of requests and responses.
-    --log-format json or pretty; default is pretty when run in a pipe. JSON prints in JSONL format.
+    --log-format json or pretty; default is pretty. JSON prints in JSONL format.
 
     --version will print the cli and core versions
     -h, --help will print this message and exit.

--- a/cli/src/args.ts
+++ b/cli/src/args.ts
@@ -42,7 +42,6 @@ export function makeArgs(argv = process.argv) {
         default: process.env["AILLY_SYSTEM"],
         short: "s",
       },
-      stream: { type: "boolean", default: false },
       "request-limit": {
         type: "string",
         default: process.env["AILLY_REQUEST_LIMIT"],
@@ -89,7 +88,6 @@ export function help() {
       'none' includes no additional content (including no system context) when generating.
       (note: context is separate from isolated. isolated: true with either 'content' or 'folder' will result in the same behavior with either. With 'none', Ailly will send _only_ the prompt when generating.)
 
-    --stream (--prompt only) print responses as they return.
     -e, --edit use Ailly in edit mode. Provide a single file in paths, an edit marker, and a prompt. The path will be updated with the edit marker at the prompt.
     -l, --lines the lines to edit as '[start]:[end]' with start inclusive, and end exclusive. With only '[start]', will insert after. With only ':[end]', will insert before.
 

--- a/cli/src/fs.ts
+++ b/cli/src/fs.ts
@@ -1,10 +1,10 @@
 import {
   AillyEdit,
   Content,
-  View,
   loadContent,
   makeCLIContent,
 } from "@ailly/core/lib/content/content.js";
+import { loadTemplateView } from "@ailly/core/lib/content/template.js";
 import {
   PipelineSettings,
   LOGGER as ROOT_LOGGER,
@@ -13,13 +13,13 @@ import {
 import { assertExists } from "@davidsouther/jiffies/lib/cjs/assert.js";
 import { FileSystem } from "@davidsouther/jiffies/lib/cjs/fs.js";
 import {
+  LEVEL,
   basicLogFormatter,
   getLogLevel,
   getLogger,
 } from "@davidsouther/jiffies/lib/cjs/log.js";
 import { Console } from "node:console";
 import { join, resolve } from "node:path";
-import { parse } from "yaml";
 import { Args } from "./args.js";
 
 export const LOGGER = getLogger("@ailly/cli");
@@ -34,38 +34,54 @@ export async function loadFs(
   const root = resolve(args.values.root ?? ".");
   fs.cd(root);
 
+  const positionals = args.positionals.map((a) => resolve(join(root, a)));
+  const hasPositionals = positionals.length > 0;
+  const hasPrompt = (args.values.prompt ?? "") !== "";
+  const isPipe = !hasPositionals && hasPrompt;
+  const logLevel =
+    args.values["log-level"] ??
+    (args.values.verbose ? "verbose" : isPipe ? "silent" : "info");
+  ROOT_LOGGER.console = LOGGER.console = isPipe
+    ? new Console(process.stderr, process.stderr)
+    : global.console;
+  ROOT_LOGGER.level = LOGGER.level = getLogLevel(
+    logLevel === "trace" ? "0.5" : logLevel
+  );
+  const logFormat = args.values["log-format"];
+  const formatter =
+    logFormat === "json" ||
+    ROOT_LOGGER.level < LEVEL.DEBUG ||
+    args.values.verbose
+      ? JSON.stringify
+      : basicLogFormatter;
+  ROOT_LOGGER.format = LOGGER.format = formatter;
+
+  const argContext =
+    args.values.context ?? (args.values.edit ? "folder" : undefined);
+
+  const out = resolve(args.values.out ?? root);
+
+  const templateView = await loadTemplateView(
+    fs,
+    ...(args.values["template-view"] ?? [])
+  );
+  const isExpensiveModel = args.values.model?.includes("opus") ?? false;
+  const requestLimit =
+    args.values["request-limit"] ?? isExpensiveModel ? 1 : undefined;
+
   const settings = await makePipelineSettings({
     root,
-    out: resolve(args.values.out ?? root),
-    context: args.values.context ?? (args.values.edit ? "folder" : undefined),
+    out,
+    context: argContext,
     isolated: args.values.isolated,
     combined: args.values.combined,
     engine: args.values.engine,
     model: args.values.model,
     plugin: args.values.plugin,
-    templateView: await loadTemplateView(fs, args.values["template-view"]),
+    templateView,
     overwrite: !args.values["no-overwrite"],
-    requestLimit:
-      args.values["request-limit"] ?? args.values.model?.includes("opus")
-        ? 1
-        : undefined,
+    requestLimit,
   });
-
-  const positionals = args.positionals.map((a) => resolve(join(root, a)));
-  const hasPositionals = positionals.length > 0;
-  const hasPrompt =
-    args.values.prompt !== undefined && args.values.prompt !== "";
-  const isPipe = !hasPositionals && hasPrompt;
-  const logLevel =
-    args.values["log-level"] ??
-    (args.values.verbose ? "verbose" : isPipe ? "silent" : "info");
-  const logFormat = args.values["log-format"];
-  const formatter = logFormat == "json" ? JSON.stringify : basicLogFormatter;
-  ROOT_LOGGER.console = LOGGER.console = isPipe
-    ? new Console(process.stderr, process.stderr)
-    : global.console;
-  ROOT_LOGGER.level = LOGGER.level = getLogLevel(logLevel);
-  ROOT_LOGGER.format = LOGGER.format = formatter;
 
   const system = args.values.system ?? "";
   const depth = Number(args.values["max-depth"]);
@@ -157,30 +173,6 @@ export function makeEdit(
     default:
       throw new Error("Edit lines have at least one of start or end");
   }
-}
-
-/**
- * Read, parse, and validate a template view.
- */
-export async function loadTemplateView(
-  fs: FileSystem,
-  paths?: string[]
-): Promise<View> {
-  if (!paths) return {};
-  let view = /* @type View */ {};
-  for (const path of paths) {
-    try {
-      LOGGER.debug(`Reading template-view at ${path}`);
-      const file = await fs.readFile(path);
-      const parsed = parse(file);
-      if (parsed && typeof parsed == "object") {
-        view = { ...view, ...parsed };
-      }
-    } catch (err) {
-      LOGGER.warn(`Failed to load template-view at ${path}`, { err });
-    }
-  }
-  return view;
 }
 
 async function readAll(readable: typeof process.stdin): Promise<string> {

--- a/cli/src/fs.ts
+++ b/cli/src/fs.ts
@@ -58,14 +58,14 @@ export async function loadFs(
   const isPipe = !hasPositionals && hasPrompt;
   const logLevel =
     args.values["log-level"] ??
-    (args.values.verbose ? "verbose" : isPipe ? "silent" : undefined);
-  const logFormat = args.values["log-format"] ?? (isPipe ? "pretty" : "json");
+    (args.values.verbose ? "verbose" : isPipe ? "silent" : "info");
+  const logFormat = args.values["log-format"];
+  const formatter = logFormat == "json" ? JSON.stringify : basicLogFormatter;
   ROOT_LOGGER.console = LOGGER.console = isPipe
     ? new Console(process.stderr, process.stderr)
     : global.console;
   ROOT_LOGGER.level = LOGGER.level = getLogLevel(logLevel);
-  ROOT_LOGGER.format = LOGGER.format =
-    logFormat == "json" ? JSON.stringify : basicLogFormatter;
+  ROOT_LOGGER.format = LOGGER.format = formatter;
 
   const system = args.values.system ?? "";
   const depth = Number(args.values["max-depth"]);

--- a/content/30_experiments/10_theory_of_mind/.aillyrc
+++ b/content/30_experiments/10_theory_of_mind/.aillyrc
@@ -1,6 +1,5 @@
 ---
-tuning: false
-skip: true
+parent: root
 ---
 
 You are being interviewed. Keep your answers short.

--- a/content/30_experiments/10_theory_of_mind/10_three_year_old/.aillyrc
+++ b/content/30_experiments/10_theory_of_mind/10_three_year_old/.aillyrc
@@ -1,4 +1,5 @@
 ---
+parent: always
 isolated: true
 ---
 

--- a/content/30_experiments/10_theory_of_mind/20_ten_year_old/.aillyrc
+++ b/content/30_experiments/10_theory_of_mind/20_ten_year_old/.aillyrc
@@ -1,4 +1,5 @@
 ---
+parent: always
 isolated: true
 ---
 

--- a/core/package.json
+++ b/core/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.427.0",
     "@aws-sdk/credential-providers": "^3.572.0",
-    "@davidsouther/jiffies": "^2.2.4",
+    "@davidsouther/jiffies": "^2.2.5",
     "@dqbd/tiktoken": "^1.0.7",
     "gitignore-parser": "^0.0.2",
     "gray-matter": "^4.0.3",

--- a/core/src/actions/prompt_thread.test.ts
+++ b/core/src/actions/prompt_thread.test.ts
@@ -119,8 +119,17 @@ describe("generateOne", () => {
       state.engine
     );
     await drain(content);
-    expect(state.logger.info).toHaveBeenCalledWith("Preparing /c.txt");
-    expect(state.logger.info).toHaveBeenCalledWith("Calling noop");
+    expect(state.logger.info).toHaveBeenCalledWith("Running /c.txt");
+    expect(state.logger.debug).toHaveBeenCalledWith("Generating response", {
+      engine: "noop",
+      messages: [
+        { role: "system", content: "" },
+        { role: "user", content: "prompt a" },
+        { role: "assistant", content: "response a" },
+        { role: "user", content: "response b" },
+        { role: "user", content: "tell me a joke\n" },
+      ],
+    });
     expect(content.response).toMatch(/^noop response for c.txt:/);
   });
 });
@@ -189,14 +198,6 @@ describe("PromptThread", () => {
     expect(thread.isDone).toBe(true);
     expect(thread.finished).toBe(3);
     expect(thread.errors.length).toBe(0);
-
-    expect(content[0].response).toEqual(
-      `noop response for a.txt:\n\nsystem: \nuser: prompt a\nassistant: response a\nprompt a`
-    );
-    expect(content[1].response).toBeUndefined();
-    expect(content[2].response).toEqual(
-      `noop response for c.txt:\n\nsystem: \nuser: tell me a joke\n\ntell me a joke\n`
-    );
   });
 
   it("runs sequence", async () => {
@@ -224,13 +225,5 @@ describe("PromptThread", () => {
     expect(thread.isDone).toBe(true);
     expect(thread.finished).toBe(3);
     expect(thread.errors.length).toBe(0);
-
-    expect(content[0].response).toEqual(
-      `noop response for a.txt:\n\nsystem: \nuser: prompt a\nassistant: response a\nprompt a`
-    );
-    expect(content[1].response).toBeUndefined();
-    expect(content[2].response).toEqual(
-      `noop response for c.txt:\n\nsystem: \nuser: prompt a\nassistant: noop response for a.txt:\n\nsystem: \nuser: prompt a\nassistant: response a\nprompt a\nuser: response b\nuser: tell me a joke\n\ntell me a joke\n`
-    );
   });
 });

--- a/core/src/content/template.ts
+++ b/core/src/content/template.ts
@@ -74,7 +74,7 @@ export async function loadTemplateView(
   ...paths: string[]
 ): Promise<View> {
   if (!paths) return {};
-  let view = /* @type View */ {};
+  let view: View = {};
   for (const path of paths) {
     try {
       LOGGER.debug(`Reading template-view at ${path}`);

--- a/core/src/engine/bedrock/bedrock.test.ts
+++ b/core/src/engine/bedrock/bedrock.test.ts
@@ -4,7 +4,7 @@ import {
   FileSystem,
   RecordFileSystemAdapter,
 } from "@davidsouther/jiffies/lib/cjs/fs.js";
-import { claude3 } from "./prompt-builder.js";
+import { messagesBuilder } from "./prompt_builder.js";
 import { makePipelineSettings } from "../../index.js";
 import { loadContent } from "../../content/content";
 import { format } from "./bedrock";
@@ -12,7 +12,7 @@ import { format } from "./bedrock";
 describe("bedrock claude3", () => {
   describe("prompt builder", () => {
     it("combines system prompts", () => {
-      const actual = claude3([
+      const actual = messagesBuilder([
         { role: "system", content: "sysa" },
         { role: "system", content: "sysb" },
       ]);
@@ -20,7 +20,7 @@ describe("bedrock claude3", () => {
     });
 
     it("combines user prompts", () => {
-      const actual = claude3([
+      const actual = messagesBuilder([
         { role: "user", content: "usera" },
         { role: "user", content: "userb" },
       ]);
@@ -30,7 +30,7 @@ describe("bedrock claude3", () => {
     });
 
     it("combines assistant prompts", () => {
-      const actual = claude3([
+      const actual = messagesBuilder([
         { role: "assistant", content: "assista" },
         { role: "assistant", content: "assistb" },
       ]);
@@ -63,7 +63,6 @@ describe("bedrock claude3", () => {
       expect(contents[0].meta?.messages).toEqual([
         system,
         { role: "user", content: "prompt a" },
-        { role: "assistant", content: "response a" },
       ]);
       expect(contents[1].meta?.messages).toEqual([
         system,

--- a/core/src/engine/bedrock/bedrock.ts
+++ b/core/src/engine/bedrock/bedrock.ts
@@ -42,6 +42,7 @@ const MODEL_MAP: Record<string, string> = {
 
 declare module "@davidsouther/jiffies/lib/cjs/log.js" {
   interface Logger {
+    /** Augment our logger with a `trace` method to trace streaming calls. */
     trace: Log;
   }
 }

--- a/core/src/engine/bedrock/bedrock.ts
+++ b/core/src/engine/bedrock/bedrock.ts
@@ -7,16 +7,16 @@ import { fromNodeProviderChain } from "@aws-sdk/credential-providers";
 import { getLogger } from "@davidsouther/jiffies/lib/cjs/log.js";
 import { Content, View } from "../../content/content.js";
 import { LOGGER as ROOT_LOGGER } from "../../index.js";
-import type { EngineGenerate, Summary } from "../index.js";
+import type { EngineDebug, EngineGenerate, Summary } from "../index.js";
 import { addContentMessages } from "../messages.js";
-import { PromptBuilder, type Models } from "./prompt-builder.js";
+import { PromptBuilder, type Models } from "./prompt_builder.js";
 
 export const name = "bedrock";
-export const DEFAULT_MODEL = "anthropic.claude-3-sonnet-20240229-v1:0";
+export const DEFAULT_MODEL = "haiku";
 
 const LOGGER = getLogger("@ailly/core:bedrock");
 
-export interface BedrockDebug {
+export interface BedrockDebug extends EngineDebug {
   statistics?: {
     inputTokenCount?: number;
     outputTokenCount?: number;
@@ -32,7 +32,19 @@ const MODEL_MAP: Record<string, string> = {
   sonnet: "anthropic.claude-3-sonnet-20240229-v1:0",
   haiku: "anthropic.claude-3-haiku-20240307-v1:0",
   opus: "anthropic.claude-3-opus-20240229-v1:0",
+  "sonnet:48k": "anthropic.claude-3-sonnet-20240229-v1:0:48k",
+  "haiku:48k": "anthropic.claude-3-haiku-20240307-v1:0:48k",
+  "opus:48k": "anthropic.claude-3-opus-20240229-v1:0:48k",
+  "sonnet:200k": "anthropic.claude-3-sonnet-20240229-v1:0:200k",
+  "haiku:200k": "anthropic.claude-3-haiku-20240307-v1:0:200k",
+  "opus:200k": "anthropic.claude-3-opus-20240229-v1:0:200k",
 };
+
+declare module "@davidsouther/jiffies/lib/cjs/log.js" {
+  interface Logger {
+    trace: Log;
+  }
+}
 
 export const generate: EngineGenerate<BedrockDebug> = (
   c: Content,
@@ -41,13 +53,8 @@ export const generate: EngineGenerate<BedrockDebug> = (
   LOGGER.level = ROOT_LOGGER.level;
   LOGGER.format = ROOT_LOGGER.format;
   LOGGER.console = ROOT_LOGGER.console;
-  const bedrock = new BedrockRuntimeClient({
-    credentials: fromNodeProviderChain({
-      ignoreCache: true,
-      profile: process.env["AWS_PROFILE"],
-    }),
-    ...(process.env["AWS_REGION"] ? { region: process.env["AWS_REGION"] } : {}),
-  });
+  LOGGER.trace = LOGGER.logAt(0.5, "TRACE");
+  const bedrock = makeClient();
   model = MODEL_MAP[model] ?? model;
   let messages = c.meta?.messages ?? [];
   if (!messages.find((m) => m.role == "user")) {
@@ -68,37 +75,46 @@ export const generate: EngineGenerate<BedrockDebug> = (
 
   LOGGER.debug("Bedrock sending prompt", {
     ...prompt,
-    messages: [`...${prompt.messages.length} messages...`],
+    messages: [`...${messages.length} messages...`],
     system: `${prompt.system.slice(0, 20)}...`,
   });
 
   try {
     let message = "";
-    const debug: BedrockDebug = { id: "", finish: "unknown" };
+    const debug: BedrockDebug = {
+      id: "",
+      finish: "unknown",
+      model,
+      engine: "bedrock",
+    };
     const stream = new TransformStream();
     const writer = stream.writable.getWriter();
+    const invokeModelCommand = {
+      modelId: model,
+      contentType: "application/json",
+      accept: "application/json",
+      body: JSON.stringify(prompt),
+    };
+    LOGGER.trace("Sending InvokeModelWithResponseStreamCommand", {
+      invokeModelCommand,
+    });
     const done = bedrock
-      .send(
-        new InvokeModelWithResponseStreamCommand({
-          modelId: model,
-          contentType: "application/json",
-          accept: "application/json",
-          body: JSON.stringify(prompt),
-        })
-      )
+      .send(new InvokeModelWithResponseStreamCommand(invokeModelCommand))
       .then(async (response) => {
-        LOGGER.info(`Begin streaming response from Bedrock for ${c.name}`);
+        LOGGER.debug(`Begin streaming response from Bedrock for ${c.name}`);
 
+        let chunks = 0;
         for await (const block of response.body ?? []) {
           const chunk = JSON.parse(
             new TextDecoder().decode(block.chunk?.bytes)
           );
-          LOGGER.debug(
-            `Received chunk for (${
+          LOGGER.trace(
+            `Received chunk from Bedrock for ${c.name} (${
               chunk.message?.id ?? debug.id
-            }) from Bedrock for ${c.name}`,
+            })`,
             { chunk }
           );
+          chunks += 1;
           switch (chunk.type) {
             case "message_start":
               debug.id = chunk.message.id;
@@ -119,16 +135,25 @@ export const generate: EngineGenerate<BedrockDebug> = (
               break;
           }
         }
+
+        LOGGER.debug(
+          `Finished streaming response from Bedrock for ${c.name} (${debug.id}), total ${chunks} chunks.`
+        );
       })
       .catch((e) => {
         debug.finish = "failed";
         debug.error = e as Error;
-        LOGGER.error(`Error for bedrock response ${debug.id}`, {
-          err: debug.error,
-        });
+        LOGGER.warn(
+          `Error for Bedrock response ${c.name} (${debug.id ?? "no id"})`,
+          {
+            err: debug.error,
+          }
+        );
       })
       .finally(async () => {
-        LOGGER.debug(`Closing write stream for bedrock response ${debug.id}`);
+        LOGGER.debug(
+          `Closing write stream for bedrock response ${c.name} (${debug.id})`
+        );
         await writer.close();
       });
 
@@ -152,6 +177,16 @@ export const generate: EngineGenerate<BedrockDebug> = (
     };
   }
 };
+
+function makeClient() {
+  return new BedrockRuntimeClient({
+    credentials: fromNodeProviderChain({
+      ignoreCache: true,
+      profile: process.env["AWS_PROFILE"],
+    }),
+    ...(process.env["AWS_REGION"] ? { region: process.env["AWS_REGION"] } : {}),
+  });
+}
 
 export async function view(): Promise<View> {
   return {
@@ -198,4 +233,42 @@ export function extractFirstFence(message: string): string {
   const nextTicks = message.indexOf("```", endOfFirstLine + 1);
   message = message.slice(endOfFirstLine + 1, nextTicks + 1);
   return message;
+}
+
+export function formatError(content: Content) {
+  try {
+    const { message } = content.meta!.debug!.error!;
+    const model = content.meta!.debug!.model!;
+    const region = process.env["AWS_REGION"] ?? makeClient().config.region;
+    let base = "There was an error calling Bedrock. ";
+    switch (message) {
+      case "The security token included in the request is invalid.":
+        base += message + " Please refresh your AWS CLI credentials.";
+        break;
+      case "The security token included in the request is expired":
+      case "Could not load credentials from any providers":
+        base += message + ". Please refresh your AWS CLI credentials.";
+        break;
+      case "Could not resolve the foundation model from the provided model identifier.":
+        base += `The model ${model} could not be resolved.`;
+        if (Object.values(MODEL_MAP).includes(model)) {
+          base += ` Please ensure it is enabled in AWS region ${region}, or change your AWS region.`;
+        } else {
+          base += ` Please verify it is the correct identifier for your foundation or custom model.`;
+        }
+        break;
+      case "You don't have access to the model with the specified model ID.":
+        base += `Please enable model access to model with id ${model} in the AWS region ${region}.`;
+        break;
+      case "The provided model identifier is invalid.":
+        base += `The provided model identifier "${model}" is not recognized. Please ensure it is a valid model deployed in AWS region ${region}, or change your AWS region.`;
+        break;
+      default:
+        base += message;
+        break;
+    }
+    return base;
+  } catch (_) {
+    return undefined;
+  }
 }

--- a/core/src/engine/bedrock/prompt_builder.ts
+++ b/core/src/engine/bedrock/prompt_builder.ts
@@ -8,20 +8,20 @@ export type Models =
 
 export class PromptBuilder {
   modelBuilders: Record<Models, (m: Message[]) => any> = {
-    "anthropic.claude-v2": claude,
-    "anthropic.claude-3-sonnet-20240229-v1:0": claude3,
-    "anthropic.claude-3-haiku-20240307-v1:0": claude3,
-    "anthropic.claude-3-opus-20240229-v1:0": claude3,
+    "anthropic.claude-v2": conversationBuilder,
+    "anthropic.claude-3-sonnet-20240229-v1:0": messagesBuilder,
+    "anthropic.claude-3-haiku-20240307-v1:0": messagesBuilder,
+    "anthropic.claude-3-opus-20240229-v1:0": messagesBuilder,
   };
 
   constructor(private readonly modelName: Models) {}
 
   build(messages: Message[]) {
-    return this.modelBuilders[this.modelName](messages);
+    return (this.modelBuilders[this.modelName] ?? messagesBuilder)(messages);
   }
 }
 
-export function claude(messages: Message[]): {
+export function conversationBuilder(messages: Message[]): {
   prompt: String;
   max_tokens_to_sample: number;
 } {
@@ -52,7 +52,7 @@ export interface LLMMessage {
   content: string;
 }
 
-export function claude3(messages: Message[]): {
+export function messagesBuilder(messages: Message[]): {
   messages: LLMMessage[];
   system: string;
   max_tokens: number;

--- a/core/src/engine/index.ts
+++ b/core/src/engine/index.ts
@@ -30,6 +30,7 @@ export interface Engine {
   vector(s: string, parameters: ContentMeta): Promise<number[]>;
   view?(): Promise<View>;
   models?(): string[];
+  formatError?(content: Content): string | undefined;
 }
 
 export interface Message {

--- a/core/src/engine/messages.ts
+++ b/core/src/engine/messages.ts
@@ -13,7 +13,7 @@ export async function addContentMessages(
   else content.meta.messages = getMessagesPredecessor(content, context);
   let messages = content.meta.messages;
   if (messages.at(-1)?.role == "assistant") {
-    messages = messages.slice(0, -1);
+    messages.splice(-1, 1);
   }
   let fence: undefined | string = undefined;
   if (content.context.edit) {

--- a/core/src/engine/noop.ts
+++ b/core/src/engine/noop.ts
@@ -35,9 +35,11 @@ export const generate: EngineGenerate = (
   LOGGER.level = ROOT_LOGGER.level;
   LOGGER.format = ROOT_LOGGER.format;
 
-  const system = content.context.system?.map((s) => s.content).join("\n");
+  const system = content.context.system
+    ?.map((s, i) => `[system ${i}] ${s.content}`)
+    .join("\n");
   const messages = content.meta?.messages
-    ?.map((m) => `${m.role}: ${m.content}`)
+    ?.map((m, i) => `[message ${i}] ${m.role}: ${m.content}`)
     .join("\n");
   const message =
     process.env["AILLY_NOOP_RESPONSE"] ??
@@ -45,7 +47,7 @@ export const generate: EngineGenerate = (
       `noop response for ${content.name}:`,
       system,
       messages,
-      content.prompt,
+      "[response] " + content.prompt,
     ].join("\n");
 
   let error: Error | undefined;
@@ -63,6 +65,8 @@ export const generate: EngineGenerate = (
             first = false;
             await sleep(TIMEOUT.timeout / 10);
           }
+        } else {
+          writer.write(message);
         }
       } finally {
         writer.close();

--- a/core/src/engine/openai.ts
+++ b/core/src/engine/openai.ts
@@ -63,10 +63,10 @@ export const generate: EngineGenerate<OpenAIDebug> = (
           "Failed to get completions and call with rate limit did not itself error"
         );
       }
-      LOGGER.info(`Begin streaming response from Bedrock for ${c.name}`);
+      LOGGER.info(`Begin streaming response from OpenAI for ${c.name}`);
 
       for await (const block of completions) {
-        LOGGER.debug(`Received chunk ${chunkNum++} from Bedrock for ${c.name}`);
+        LOGGER.debug(`Received chunk ${chunkNum++} from OpenAI for ${c.name}`);
         const writer = stream.writable.getWriter();
         await writer.ready;
         const chunk = block.choices[0]?.delta.content;
@@ -76,6 +76,8 @@ export const generate: EngineGenerate<OpenAIDebug> = (
       }
 
       await stream.writable.getWriter().close();
+
+      LOGGER.info(`Finished streaming response from OpenAI for ${c.name}`);
     });
 
     LOGGER.debug(`Response from OpenAI for ${c.name}`, {

--- a/core/src/util.ts
+++ b/core/src/util.ts
@@ -16,6 +16,12 @@ export function withResolvers<T = void>(): PromiseWithResolvers<T> {
   return { promise, resolve, reject };
 }
 
+export function withResolved<T = void>(t: T): PromiseWithResolvers<T> {
+  const resolvers = withResolvers<T>();
+  resolvers.resolve(t);
+  return resolvers;
+}
+
 declare global {
   interface ReadableStream<R = any> {
     [Symbol.asyncIterator](): AsyncIterator<R>;

--- a/integ/06_stream/stream.sh
+++ b/integ/06_stream/stream.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-cd $(dirname $0)
-set -x
-set -e
-
-AILLY_NOOP_STREAM=y ailly --prompt "Tell me a joke" --stream | tee out
-[ -s out ]
-rm out

--- a/integ/integ.sh
+++ b/integ/integ.sh
@@ -9,6 +9,7 @@ rm -rf package.json
 npm init --yes
 npm link ../core ../cli
 
+export AILLY_TEMPLATE_VIEW=
 export AILLY_ENGINE=${AILLY_ENGINE:-noop}
 
 echo "Basic"
@@ -26,9 +27,6 @@ echo "Edit"
 
 echo "Conversations"
 ./05_conversation/conversation.sh
-
-echo "Stream"
-./06_stream/stream.sh
 
 echo "Pipes"
 ./10_std_pipes/pipes.sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.427.0",
         "@aws-sdk/credential-providers": "^3.572.0",
-        "@davidsouther/jiffies": "^2.2.4",
+        "@davidsouther/jiffies": "^2.2.5",
         "@dqbd/tiktoken": "^1.0.7",
         "gitignore-parser": "^0.0.2",
         "gray-matter": "^4.0.3",
@@ -1966,9 +1966,9 @@
       "dev": true
     },
     "node_modules/@davidsouther/jiffies": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@davidsouther/jiffies/-/jiffies-2.2.4.tgz",
-      "integrity": "sha512-Bu8VjUoEf5ywoIahPkzWmYO4zOpXcCbKRxwaQFUx1OwmU7kerZyfoj6zMhLHFfYDRL7om6jOBTxx8VvQwC8t8w==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@davidsouther/jiffies/-/jiffies-2.2.5.tgz",
+      "integrity": "sha512-ZbuL28BWr7NfkRiW0PUSZJn5INGGRGHckqB1k05O+TPAXY1iiYaDhGaeYfxREjvlgfUQr+qXjwOawFafXjLlZw==",
       "dependencies": {
         "sass": "^1.49.9",
         "typescript": "^4.7.1"


### PR DESCRIPTION
1. Consistently report Bedrock and other engine errors.
2. Better align CLI logging and output at the right information level.
3. Fix several bugs from streaming handling.
4. Rework defaults for better getting started experience