### PR TITLE
Feat: allow prompt in combined: false head

### DIFF
--- a/core/src/content/content.test.ts
+++ b/core/src/content/content.test.ts
@@ -104,6 +104,18 @@ test("it loads content", async () => {
   });
 });
 
+test("it loads prompt from head in combined: false", async () => {
+  const testFs = new FileSystem(
+    new ObjectFileSystemAdapter({
+      "a.md": "---\nprompt: prompt\n---\n",
+    })
+  );
+
+  const content = await loadContent(testFs, [], { combined: false });
+
+  expect(content["/a.md"].prompt).toBe("prompt");
+});
+
 test("it loads responses", async () => {
   const testFs = new FileSystem(
     new ObjectFileSystemAdapter({

--- a/core/src/content/content.ts
+++ b/core/src/content/content.ts
@@ -161,13 +161,23 @@ async function loadFile(
 
     let response: string | undefined;
     let outPath: string;
-    if (data.prompt) {
+    const combined = head.combined ?? data.combined;
+    if (data.prompt && combined !== false) {
       outPath = promptPath;
       response = prompt;
       data.combined = true;
       prompt = data.prompt;
       delete data.prompt;
     } else {
+      if (data.prompt !== undefined) {
+        if (prompt.trim().length > 0) {
+          LOGGER.warn(`Head and body both have prompt, skipping ${file.name}`);
+          data.skip = true;
+        } else {
+          prompt = data.prompt;
+        }
+      }
+
       outPath =
         head.out === undefined || head.root === head.out
           ? promptPath


### PR DESCRIPTION
Even if the file is combined: false, allow using the prompt: greymatter (but warn and prefer the body).