### PR TITLE
Replace mime-types extension with handrolled check.

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -32,7 +32,6 @@
     "@dqbd/tiktoken": "^1.0.7",
     "gitignore-parser": "^0.0.2",
     "gray-matter": "^4.0.3",
-    "mime-types": "^2.1.35",
     "mustache": "^4.2.0",
     "openai": "^4.11.1",
     "temporal-polyfill": "^0.2.4",
@@ -40,7 +39,6 @@
     "yaml": "^2.4.1"
   },
   "devDependencies": {
-    "@types/mime-types": "^2.1.4",
     "@types/mustache": "^4.2.5",
     "vitest": "^1.5.0"
   }

--- a/core/src/content/gitignore_fs.test.ts
+++ b/core/src/content/gitignore_fs.test.ts
@@ -3,6 +3,16 @@ import { describe, expect, it } from "vitest";
 import { GitignoreFs } from "./gitignore_fs.js";
 
 describe("gitignore fs", () => {
+  it("skips files with no extension", async () => {
+    const fs = new GitignoreFs(
+      new ObjectFileSystemAdapter({
+        "file.txt": "abc",
+        skip: "skip",
+      })
+    );
+
+    expect(await fs.readdir("/")).toEqual(["file.txt"]);
+  });
   it("reads while obeying .gitignores", async () => {
     const fs = new GitignoreFs(
       new ObjectFileSystemAdapter({

--- a/integ/package.json
+++ b/integ/package.json
@@ -1,12 +1,13 @@
 {
   "name": "integ",
   "version": "1.0.0",
-  "description": "",
   "main": "index.js",
+  "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "description": ""
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,10 @@
     },
     "cli": {
       "name": "@ailly/cli",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "ISC",
       "dependencies": {
-        "@ailly/core": "1.5.0",
+        "@ailly/core": "1.5.1",
         "@davidsouther/jiffies": "^2.2.4",
         "yaml": "^2.4.1"
       },
@@ -33,7 +33,7 @@
     },
     "core": {
       "name": "@ailly/core",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.427.0",
@@ -42,7 +42,6 @@
         "@dqbd/tiktoken": "^1.0.7",
         "gitignore-parser": "^0.0.2",
         "gray-matter": "^4.0.3",
-        "mime-types": "^2.1.35",
         "mustache": "^4.2.0",
         "openai": "^4.11.1",
         "temporal-polyfill": "^0.2.4",
@@ -50,7 +49,6 @@
         "yaml": "^2.4.1"
       },
       "devDependencies": {
-        "@types/mime-types": "^2.1.4",
         "@types/mustache": "^4.2.5",
         "vitest": "^1.5.0"
       },
@@ -60,9 +58,9 @@
     },
     "extension": {
       "name": "ailly",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "dependencies": {
-        "@ailly/core": "1.5.0",
+        "@ailly/core": "1.5.1",
         "@davidsouther/jiffies": "^2.1.3"
       },
       "devDependencies": {
@@ -3703,12 +3701,6 @@
       "dependencies": {
         "@types/unist": "*"
       }
-    },
-    "node_modules/@types/mime-types": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
-      "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
-      "dev": true
     },
     "node_modules/@types/mocha": {
       "version": "10.0.6",
@@ -13291,9 +13283,9 @@
     },
     "web": {
       "name": "@ailly/web",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "dependencies": {
-        "@ailly/core": "1.5.0",
+        "@ailly/core": "1.5.1",
         "@davidsouther/jiffies": "^2.2.4",
         "marked-react": "^2.0.0",
         "react": "^18",


### PR DESCRIPTION
`ailly` cli was ignoring python files. The root cause was the `mime-types` extension which didn't properly address our usecase of filtering out binary files. This replaces that package with our own logic.